### PR TITLE
Add containerization from upstream selfhost branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# dependencies
+node_modules
+
+# sensitive
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:current
+
+ARG buildno
+ARG commitsha
+
+ENV NODE_ENV=production
+
+
+LABEL author="Curtis Fowler (curtisf)" \
+      repository="https://github.com/curtisf/logger"
+
+RUN mkdir /opt/bot
+# Copy files and install modules
+COPY *.js /opt/bot/
+COPY *.json /opt/bot/
+COPY *.md /opt/bot/
+COPY src /opt/bot/src
+WORKDIR /opt/bot
+RUN npm i --production
+
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -13,33 +13,13 @@ Logger is a powerful [Discord](https://discordapp.com) bot meant to give staff m
 This route uses Docker and a docker-compose file to bring up the required dependencies for Logger.
 
 1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) if on Windows, and [regular Docker on Linux systems](https://docs.docker.com/engine/install/ubuntu/)
-2. Download the bot code via `git clone https://github.com/curtisf/logger` or clicking "<> Code -> Download Zip" on the GitHub page
+2. Download the bot code via `git clone` or clicking "<> Code -> Download Zip" on the GitHub page
 3. In the bot code folder, copy/rename .env.example into .env
-4. Fill out **all** values in your .env file
+4. Fill out the values in your .env file
 5. Run `docker compose up` to start the bot and dependent services. This will make two folders in the same folder that the command is ran in: pgdata and redisdata, used for storing database information. If you want to change the location that postgres and redis data is stored, check out the volume mounts in `docker-compose.yml`.
-6. The bot should be up and running in Discord if all values are present. The database tables will be initialized upon the bot starting, or you can initialize them using `node src/miscellaneous/generateDB.js`.
-7. If you have issues, check the logs for `docker compose up`. Otherwise, you're done, and can use `docker compose up -d` to run the bot in the background 24/7
-8. To setup slash commands, use:
-
-Set global commands:
-
-```bash
-node src/miscellaneous/setslashcmds.js
-```
-
-Set commands in one server:
-
-```bash
-node src/miscellaneous/setslashcmds.js --scope guild --guild-id "paste your server id"
-```
-
-To view script help information:
-
-```bash
-node src/miscellaneous/setslashcmds.js --help
-```
-
-9. Alternatively to using the setslashcmds script, you can use your chosen GLOBAL_BOT_PREFIX to set the bot's commands. If yours is %, then you'd do `%setcmd global` to globally set commands, and `%setcmd guild` to quickly set server-specific slash commands.
+6. Run `docker compose exec loggerbot npm run genDB` to initialize the database tables.
+7. The bot should be up and running in Discord if all necessary values are present.
+8. If you have issues, check the logs for `docker compose up`. Otherwise, you're done, and can use `docker compose up -d` to run the bot in the background 24/7
 
 ### Making changes with Docker
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<center><img src="https://cdn.discordapp.com/attachments/349356606883889152/616414555639382016/Logger.png" />
-<a href="https://discordbots.org/bot/298822483060981760" >
-  <img src="https://discordbots.org/api/widget/298822483060981760.svg" alt="Logger" />
-</a>
-</center>
+# Logger
+
+![Logger](https://cdn.discordapp.com/attachments/349356606883889152/616414555639382016/Logger.png)
+
+[![Logger](https://discordbots.org/api/widget/298822483060981760.svg)](https://discordbots.org/bot/298822483060981760)
 
 ## Logger's official instance closed 04/05/2024, but can still be selfhosted and modified by users
 

--- a/README.md
+++ b/README.md
@@ -4,23 +4,64 @@
 </a>
 </center>
 
-Logger is a powerful [Discord](https://discordapp.com) bot meant to give staff members oversight over the various actions taking place in their server. Come talk about me with my creator at [Logger's Lounge](https://discord.gg/ed7Gaa3).
+## Logger's official instance closed 04/05/2024, but can still be selfhosted and modified by users
 
-## Installation
+Logger is a powerful [Discord](https://discordapp.com) bot meant to give staff members oversight over the various actions taking place in their server. Come talk about it in the server [Logger's Lounge](https://discord.gg/ed7Gaa3).
 
-You are mostly on your own selfhosting this version. Required applications:
-- PostgreSQL 11
+## Installation via Docker
+
+This route uses Docker and a docker-compose file to bring up the required dependencies for Logger.
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) if on Windows, and [regular Docker on Linux systems](https://docs.docker.com/engine/install/ubuntu/)
+2. Download the bot code via `git clone https://github.com/curtisf/logger` or clicking "<> Code -> Download Zip" on the GitHub page
+3. In the bot code folder, copy/rename .env.example into .env
+4. Fill out **all** values in your .env file
+5. Run `docker compose up` to start the bot and dependent services. This will make two folders in the same folder that the command is ran in: pgdata and redisdata, used for storing database information. If you want to change the location that postgres and redis data is stored, check out the volume mounts in `docker-compose.yml`.
+6. The bot should be up and running in Discord if all values are present. The database tables will be initialized upon the bot starting, or you can initialize them using `node src/miscellaneous/generateDB.js`.
+7. If you have issues, check the logs for `docker compose up`. Otherwise, you're done, and can use `docker compose up -d` to run the bot in the background 24/7
+8. To setup slash commands, use:
+
+Set global commands:
+
+```bash
+node src/miscellaneous/setslashcmds.js
+```
+
+Set commands in one server:
+
+```bash
+node src/miscellaneous/setslashcmds.js --scope guild --guild-id "paste your server id"
+```
+
+To view script help information:
+
+```bash
+node src/miscellaneous/setslashcmds.js --help
+```
+
+9. Alternatively to using the setslashcmds script, you can use your chosen GLOBAL_BOT_PREFIX to set the bot's commands. If yours is %, then you'd do `%setcmd global` to globally set commands, and `%setcmd guild` to quickly set server-specific slash commands.
+
+### Making changes with Docker
+
+If you modify the bot code, the code must be rebuilt for use with `docker compose`.
+Make the code changes, and use `docker compose build loggerbot` to rebuild the code, then it can be started at will using `docker compose up` or `docker compose up -d`
+
+## Installation without Docker
+
+You are mostly on your own selfhosting. Required applications:
+
+- PostgreSQL 14+ (no complex queries, most should work)
 - Redis
-- NodeJS 14+ (14.5.0)
+- NodeJS 20+
 
 1. Setup Postgres and add a superuser (default user works)
 2. Clone bot repo and enter the created folder
 3. Copy .env.example into .env
 4. Fill out **all** fields in it (even Sentry unless you hotpatch it out)
 5. `npm install`
-6. `node src/miscellaneous/generateDB.js`
+6. `npm run genDB`
 7. Set `ENABLE_TEXT_COMMANDS="true"` in .env
-8. `node index.js`
+8. Start the bot with `node index.js`
 9. Use your prefix to set the bot's commands. If yours is %, then you'd do `%setcmd global` to globally set commands, and `%setcmd guild` to quickly set server-specific slash commands
 
 ## Usage
@@ -29,11 +70,23 @@ You are mostly on your own selfhosting this version. Required applications:
 node index.js
 ```
 
+## Non-Docker Usage
+
+```bash
+NODE_ENV=production node index.js
+```
+
+## Support/Communication
+
+Join the community to talk about contributions and potential help at [Logger's Lounge](https://discord.gg/ed7Gaa3).
+
 ## Contributing
+
 Pull requests are welcome as long as it follows the following guidelines:
+
 1. Is your idea really one that a large group of moderators would like?
 2. Is your idea scalable?
 3. Will your idea cause the bot to hit it's global ratelimit?
-4. Have you proposed it to *piero#5432* in my [support server?](https://discord.gg/ed7Gaa3)
+4. Have you proposed it in my [support server?](https://discord.gg/ed7Gaa3)
 
-If you have done all of the above steps, then open a pull request and I will review it. Style guide and testing will be implemented in a later update.
+If you have done all of the above steps, then open a pull request and I will review it.  eventually. Run the styleguide (standard-js) against your code with `npx standard --fix ./`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3'
+services:
+  loggerbot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      "./.env"
+    links:
+      - postgres
+      - redis
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+  postgres:
+    image: postgres
+    environment:
+        - POSTGRES_USER=${PGUSER}
+        - POSTGRES_PASSWORD=${PGPASSWORD}
+        - POSTGRES_DB=${PGDATABASE}
+    env_file:
+      "./.env"
+    ports:
+        - "5432:5432"
+    volumes:
+        - ./pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PGUSER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
This PR aims to integrate the self-hosted containerized installation method from https://github.com/curtisf/logger/tree/selfhost into this repository. I have tested and ensured that the Dockerfile can be used as is with no other updates needed, and though I have not personally tested the docker-compose file it should not introduce any more complexity.